### PR TITLE
Revert "fix: temporarily remove feature events endpoint"

### DIFF
--- a/api-1/api-reference.md
+++ b/api-1/api-reference.md
@@ -75,6 +75,10 @@ https://staging.front.bucket.co/openapi.yaml
 https://staging.front.bucket.co/openapi.yaml
 {% endswagger %}
 
+{% swagger src="https://staging.front.bucket.co/openapi.yaml" path="/features/events" method="post" expanded="true" %}
+https://staging.front.bucket.co/openapi.yaml
+{% endswagger %}
+
 {% swagger src="https://staging.front.bucket.co/openapi.yaml" path="/user" method="post" expanded="true" %}
 https://staging.front.bucket.co/openapi.yaml
 {% endswagger %}


### PR DESCRIPTION
Reverts bucketco/docs#5

OpenAPI was fixed so reverting this.