### PR TITLE
Adding vue.js sdk docs to the sidebar

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -9,6 +9,9 @@
 * [Overview](supported-languages/overview.md)
 * [React SDK](sdk/@bucketco/react-sdk/README.md)
   * [Reference](sdk/@bucketco/react-sdk/globals.md)
+* [Vue SDK](sdk/@bucketco/vue-sdk/README.md)
+  * [Reference](sdk/@bucketco/vue-sdk/globals.md)
+
 * [Browser SDK](sdk/@bucketco/browser-sdk/README.md)
   * [Feedback](sdk/documents/browser-sdk/FEEDBACK.md)
   * [Reference](sdk/@bucketco/browser-sdk/globals.md)


### PR DESCRIPTION
Can go in once https://github.com/bucketco/bucket-javascript-sdk/pull/432 has been merged and the new docs copied in.